### PR TITLE
Removes double key from array

### DIFF
--- a/php-iban.php
+++ b/php-iban.php
@@ -177,7 +177,6 @@ function iban_mod97_10($numeric_representation) {
 # Get an array of all the parts from an IBAN
 function iban_get_parts($iban) {
  return array(
-         'country'		=>      iban_get_country_part($iban),
  	 'checksum'		=>	iban_get_checksum_part($iban),
 	 'bban'			=>	iban_get_bban_part($iban),
  	 'bank'			=>	iban_get_bank_part($iban),


### PR DESCRIPTION
The contents of the result obviously do not change, but even the order does not as the second definition overwrites the first one.

The key `country` is still in here (line 183)