### PR TITLE
Omit PHP closing tags (PSR-2)

### DIFF
--- a/oophp-iban.php
+++ b/oophp-iban.php
@@ -215,4 +215,3 @@ Class IBANCountry {
 
 }
 
-?>

--- a/php-iban.php
+++ b/php-iban.php
@@ -1211,4 +1211,3 @@ function _iban_nationalchecksum_implementation($iban,$mode) {
  return '';
 }
 
-?>

--- a/utils/bis-banks
+++ b/utils/bis-banks
@@ -21,4 +21,4 @@ for($i=0;$i<count($matches[0]);$i++) {
  print $matches[0][$i] . "|" . $matches[1][$i] . "|" . $matches[2][$i] . "|" . $matches[3][$i] . "\n";
 }
 
-?>
+

--- a/utils/convert-registry.php
+++ b/utils/convert-registry.php
@@ -316,4 +316,3 @@ function swift_tokenize($string,$calculate_offsets=0) {
  return $matches;
 }
 
-?>

--- a/utils/dump.php
+++ b/utils/dump.php
@@ -12,4 +12,3 @@ require_once(dirname(dirname(__FILE__)) . '/php-iban.php');
 # display registry contents
 print_r($_iban_registry);
 
-?>

--- a/utils/explode-iban
+++ b/utils/explode-iban
@@ -10,4 +10,4 @@ $iban = $argv[1];
 $parts = iban_get_parts($argv[1]);
 print_r($parts);
 exit(0);
-?>
+

--- a/utils/ootest.php
+++ b/utils/ootest.php
@@ -190,4 +190,4 @@ foreach($countries as $countrycode) {
 
 exit($errors);
 
-?>
+

--- a/utils/other-tests.php
+++ b/utils/other-tests.php
@@ -172,4 +172,5 @@ else {
 
 print "All tests passed.\n";
 exit(0);
-?>
+
+

--- a/utils/test.php
+++ b/utils/test.php
@@ -188,4 +188,4 @@ foreach($_iban_registry as $country) {
 
 exit($errors);
 
-?>
+

--- a/utils/validate-list.php
+++ b/utils/validate-list.php
@@ -89,4 +89,4 @@ function usage() {
  exit(1);
 }
 
-?>
+


### PR DESCRIPTION
Can cause unwanted output or PHP errors and following the [PSR-2 coding style guide](https://www.php-fig.org/psr/psr-2/#22-files). 