### PR TITLE
drop unsupported php versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,6 @@
-matrix:
-  include:
-    - php: 5.2
-      dist: precise
-    - php: 5.3
-      dist: precise
 language: php
 dist: trusty
 php:
- - '5.4'
- - '5.5'
  - '5.6'
  - '7.0'
  - nightly


### PR DESCRIPTION
these php version are not supported by the php-project, therefore supporting them in this lib isn't a good idead.

IMO we should also drop HHVM, but this is up 2 you.