### PR TITLE
Make loading data on demand

### DIFF
--- a/php-iban.php
+++ b/php-iban.php
@@ -376,6 +376,7 @@ function iban_country_get_central_bank_name($iban_country) {
 
 # Get the list of all IBAN countries
 function iban_countries() {
+ _iban_load_registry();
  global $_iban_registry;
  return array_keys($_iban_registry);
 }
@@ -471,7 +472,6 @@ function iban_mistranscription_suggestions($incorrect_iban) {
 # Load the IBAN registry from disk.
 global $_iban_registry;
 $_iban_registry = array();
-_iban_load_registry();
 function _iban_load_registry() {
  global $_iban_registry;
  # if the registry is not yet loaded, or has been corrupted, reload
@@ -538,6 +538,7 @@ function _iban_get_info($iban,$code) {
 
 # Get information from the IBAN registry by country / code combination
 function _iban_country_get_info($country,$code) {
+ _iban_load_registry();
  global $_iban_registry;
  $country = strtoupper($country);
  $code = strtolower($code);


### PR DESCRIPTION
The patch makes loading the php-iban data from registry.txt on demand.

This avoid loading unnecessary information into php when not using any php-iban* function, especially when using composer and autoloading php-iban.