### PR TITLE
Fix license in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "globalcitizen/php-iban",
   "description": "php-iban is a library for parsing and validating IBAN (and IIBAN) bank account information.",
-  "license": "LGPL-3.0",
+  "license": "LGPL-3.0-only",
   "autoload": {
     "files": ["oophp-iban.php","php-iban.php"]
   }


### PR DESCRIPTION
As per the [`composer.json` specification](https://getcomposer.org/doc/04-schema.md#license) the license should be a proper identifier from the [SPDX License List](https://spdx.org/licenses/). For LGPL 3.0 the proper identifier is either `LGPL-3.0-only` or `LGPL-3.0-or-later`.