### PR TITLE
Fix national checksum calculation for Belgium

### DIFF
--- a/php-iban.php
+++ b/php-iban.php
@@ -714,13 +714,13 @@ function _iso7064_mod97_10($str) {
 }
 
 # Implement the national checksum for a Belgium (BE) IBAN
-#  (Credit: @gaetan-be)
+#  (Credit: @gaetan-be, fixed by @Olympic1)
 function _iban_nationalchecksum_implementation_be($iban,$mode) {
  if($mode != 'set' && $mode != 'find' && $mode != 'verify') { return ''; } # blank value on return to distinguish from correct execution
  $nationalchecksum = iban_get_nationalchecksum_part($iban);
- $account = iban_get_account_part($iban);
- $account_less_checksum = substr($account,strlen($account)-2);
- $expected_nationalchecksum = $account_less_checksum % 97;
+ $bban = iban_get_bban_part($iban);
+ $bban_less_checksum = substr($bban, 0, -strlen($nationalchecksum));
+ $expected_nationalchecksum = $bban_less_checksum % 97;
  if($mode=='find') {
   return $expected_nationalchecksum;
  }


### PR DESCRIPTION
The function never validated the national checksum for Belgium correctly. What it did was:
- Get the checksum from the IBAN
- Remove the bankID from the BBAN to get the account
- Get the checksum from the account
- Calculate the checksum with mod 97
- Check if the calculated checksum is the same as the checksum from the IBAN (Which will always be true)

I changed it so that it now calculates it following the correct rules.
- Get the checksum from the IBAN
- Get the BBAN from the IBAN
- Remove the checksum from the BBAN
- Calculate the checksum from the left over BBAN with mod 97
- Check if the calculated checksum is the same as the checksum from the IBAN

Here is a script with the current and new code
https://onlinephp.io/c/60fa7