### PR TITLE
Allow running obfuscation-test.php from other directory

### DIFF
--- a/utils/obfuscation-test.php
+++ b/utils/obfuscation-test.php
@@ -1,6 +1,7 @@
 <?php
-require_once('../php-iban.php');
-$ibans = `cat example-ibans/*`;
+require_once(dirname(dirname(__FILE__)) . '/php-iban.php');
+$dir = dirname(__FILE__);
+$ibans = `cat $dir/example-ibans/*`;
 $lines = explode("\n",$ibans);
 foreach($lines as $iban) {
  $iban = iban_to_machine_format($iban);


### PR DESCRIPTION
This allows running obfuscation-test.php from the upper directory, by using relative require_once like in the other tests and passing a dir for the command collecting the example IBANs.