### PR TITLE
Avoid deprecated call

### DIFF
--- a/php-iban.php
+++ b/php-iban.php
@@ -586,7 +586,7 @@ function _iban_get_info($iban,$code) {
 function _iban_country_get_info($country,$code) {
  _iban_load_registry();
  global $_iban_registry;
- $country = strtoupper($country);
+ $country = null !== $country ? strtoupper($country) : null;
  $code = strtolower($code);
  if(array_key_exists($country,$_iban_registry)) {
   if(array_key_exists($code,$_iban_registry[$country])) {


### PR DESCRIPTION
> Deprecated: strtoupper(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/vendor/globalcitizen/php-iban/php-iban.php on line 589